### PR TITLE
fixed links to swcarpentry lessons

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ helper:      # list of names like above
 contact: dibsi.training@gmail.com    # contact email address for workshop organizer, such as "grace@hopper.org"
 etherpad: http://pad.software-carpentry.org/DIBSI-TTT-Monday    # optional (insert the URL for your Etherpad if you're using one)
 eventbrite:       # optional (insert the alphanumeric key for Eventbrite registration, e.g., "1234567890AB")
-prep-repository:  # optional (insert the URL for the repository where the trainees are supposed to submit the PR 
+prep-repository:  # optional (insert the URL for the repository where the trainees are supposed to submit the PR
 ---
 {% if page.eventbrite %}
 <iframe
@@ -29,7 +29,7 @@ prep-repository:  # optional (insert the URL for the repository where the traine
 
 <p>
   This week-long workshop is intended for people interested in teaching, reusing
-  and repurposing the <a href="{{site.swc_site}}">Software Carpentry</a>, 
+  and repurposing the <a href="{{site.swc_site}}">Software Carpentry</a>,
   <a href="{{site.dc_site}}">Data Carpentry</a> or <a href="angus.readthedocs.io/en/2016/">Analyzing
   High Throughput Sequencing Data</a> materials. It covers the basics of
   educational psychology and instructional design, and looks at how to
@@ -39,12 +39,12 @@ prep-repository:  # optional (insert the URL for the repository where the traine
   the teaching techniques which we will discuss. This is training for
   teaching, not technical training; will be working on development of bioinformatics
   materials, but will not be teaching that content. This workshop builds upon the
-  Carpentries instructor training, with added content pertaining to the 
+  Carpentries instructor training, with added content pertaining to the
   practicalities of organizing workshops with diverse formats
   and settings, development of genomics lessons, and includes some stages of instructor
   checkout for those who wish to complete the Carpentries certification.
-  The Carpentries' mission is to help scientists and engineers get more research done 
-  in less time and with less pain by teaching them basic lab skills for scientific computing.  
+  The Carpentries' mission is to help scientists and engineers get more research done
+  in less time and with less pain by teaching them basic lab skills for scientific computing.
   The constantly revised and updated Carpentries' Instructor Training curriculum is accessible
  <a href="{{site.swc_githubio}}/instructor-training/">here</a>.
 </p>
@@ -52,7 +52,7 @@ prep-repository:  # optional (insert the URL for the repository where the traine
 <p>
   <strong>Who:</strong> The course is aimed at everyone who is
   interested in becoming a better teacher. In particular, this training
-  is aimed at those who want to teach technical workshops, develop their 
+  is aimed at those who want to teach technical workshops, develop their
   own workshop materials, and/or become Software and Data Carpentry
   instructors and contribute to the Carpentry training
   materials.  You don't currently have to be an instructor or a
@@ -204,7 +204,7 @@ prep-repository:  # optional (insert the URL for the repository where the traine
 <p>
   Course material may be found <a href="https://dib-lab.github.io/DIBSI-instructor-training/">here</a>. Note that we will be using
 the schedule above, but the links contained in the sample schedule will lead to the relevant content.
-  
+
 </p>
 
 
@@ -212,7 +212,7 @@ the schedule above, but the links contained in the sample schedule will lead to 
 
 <h2 id="preparation" name="preparation">Preparation</h2>
 
-<p>   
+<p>
 <h3>Reading</h3>
     Please read these two short papers, which provide a brief overview of some key evidence-based results in teaching:
 
@@ -231,9 +231,9 @@ If you are interested in doing more reading, you may enjoy:</li>
   and about what we should be doing instead</li>
 <li><a href="http://www.amazon.com/Teaching-What-You-Dont-Know/dp/0674066170/">Teaching What You Don't Know</a>,
   which is a situation many of us find ourselves in more often that we'd like.</li>
-</p> 
-<h3>Lessons</h3> 
-<p>  
+</p>
+<h3>Lessons</h3>
+<p>
 Please choose *one* episode from the list below and read through it carefully.
     You will be using your selected episode for several in-class exercises,
     so be sure you are comfortable with the content.
@@ -253,9 +253,9 @@ Please choose *one* episode from the list below and read through it carefully.
 <p>
   <strong>Software Carpentry</strong>
 
-<li> Working with Files and Directories in the Unix Shell: <a href="{{ site.swc_pages }}/shell-novice/03-create/">https://swcarpentry.github.io/shell-novice/03-create/</a></li>
-<li> Tracking Changes in Git: <a href="{{ site.swc_pages }}/git-novice/04-changes/">https://swcarpentry.github.io/git-novice/04-changes/</a></li>
-<li> Selecting Data in SQL: <a href="{{ site.swc_pages }}/sql-novice-survey/01-select/">https://swcarpentry.github.io/sql-novice-survey/01-select/ </a></li>
-<li> Repeating Actions with Loops in Python: <a href="{{ site.swc_pages }}/python-novice-inflammation/02-loop/">https://swcarpentry.github.io/python-novice-inflammation/02-loop/ </a></li>
-<li> Exploring Data Frames in R: <a href="{{ site.swc_pages }}/r-novice-gapminder/05-data-structures-part2/">https://swcarpentry.github.io/r-novice-gapminder/05-data-structures-part2/</a></li>
+<li> Working with Files and Directories in the Unix Shell: <a href="{{ site.swc_githubio }}/shell-novice/03-create/">https://swcarpentry.github.io/shell-novice/03-create/</a></li>
+<li> Tracking Changes in Git: <a href="{{ site.swc_githubio }}/git-novice/04-changes/">https://swcarpentry.github.io/git-novice/04-changes/</a></li>
+<li> Selecting Data in SQL: <a href="{{ site.swc_githubio }}/sql-novice-survey/01-select/">https://swcarpentry.github.io/sql-novice-survey/01-select/ </a></li>
+<li> Repeating Actions with Loops in Python: <a href="{{ site.swc_githubio }}/python-novice-inflammation/02-loop/">https://swcarpentry.github.io/python-novice-inflammation/02-loop/ </a></li>
+<li> Exploring Data Frames in R: <a href="{{ site.swc_githubio }}/r-novice-gapminder/05-data-structures-part2/">https://swcarpentry.github.io/r-novice-gapminder/05-data-structures-part2/</a></li>
 </p>


### PR DESCRIPTION
Hi!

in "Lessons" (bottom of the index) the links to software carpentry lessons were not working.

The variable to use for the swcarpentry lessons website was `swc_githubio` , not `swc_pages` (see _config.yml)

My editor also apparently caught some trailing spaces, I can revert those if needed.

Hope that helps, and see you tomorrow! 😄 🐨 🎉 